### PR TITLE
Create card

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -21,23 +21,26 @@ class HomePage extends StatelessWidget {
       body: Center(
         child: Column(
           children: [
-            Card(
-              shape: RoundedRectangleBorder(
-                side: BorderSide(
-                  color: HexColor('002E94'),
+            GestureDetector(
+              onTap: () => _onPressed(context, const WidgetKey()),
+              child: Card(
+                shape: RoundedRectangleBorder(
+                  side: BorderSide(
+                    color: HexColor('002E94'),
+                  ),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
                 ),
-                borderRadius: const BorderRadius.all(Radius.circular(12)),
-              ),
-              elevation: 0,
-              child: SizedBox(
-                width: 200,
-                height: 100,
-                child: Center(
-                  child: Text(
-                    'Learning widget key',
-                    style: TextStyle(
-                      color: HexColor('002E94'),
-                      fontWeight: FontWeight.bold,
+                elevation: 0,
+                child: SizedBox(
+                  width: 200,
+                  height: 100,
+                  child: Center(
+                    child: Text(
+                      'Learning widget key',
+                      style: TextStyle(
+                        color: HexColor('002E94'),
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -8,7 +8,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: HexColor('FFE7CC'),
+      backgroundColor: HexColor('FFF7E9'),
       appBar: AppBar(
         title: Text(
           'Flutter Play Ground',
@@ -21,10 +21,28 @@ class HomePage extends StatelessWidget {
       body: Center(
         child: Column(
           children: [
-            ElevatedButton(
-              child: const Text('Learning widget key'),
-              onPressed: () => _onPressed(context, const WidgetKey()),
-            ),
+            Card(
+              shape: RoundedRectangleBorder(
+                side: BorderSide(
+                  color: HexColor('002E94'),
+                ),
+                borderRadius: const BorderRadius.all(Radius.circular(12)),
+              ),
+              elevation: 0,
+              child: SizedBox(
+                width: 200,
+                height: 100,
+                child: Center(
+                  child: Text(
+                    'Learning widget key',
+                    style: TextStyle(
+                      color: HexColor('002E94'),
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+            )
           ],
         ),
       ),


### PR DESCRIPTION
## やったこと
- Card Widget 追加
  - [Card class - material library - Dart API](https://api.flutter.dev/flutter/material/Card-class.html)
  - [Splitting the Card into Elevated, Filled, Outlined. · Issue #113564 · flutter/flutter · GitHub](https://github.com/flutter/flutter/issues/113564)



- GestureDetector Widget 追加
  - onTap できるようにするには、`InkWell ` か `GestureDetector Widget`
> InkWell is a material widget and it can show you a Ripple Effect whenever a touch was received.
GestureDetector Widget is more general-purpose, not only for touch but also for other gestures.
[How to Make Card Clickable In Flutter? | Flutter Agency](https://flutteragency.com/how-to-make-card-clickable-in-flutter/)

## そのほか
- [Flutterのリップルエフェクトは一癖ある - Qiita](https://qiita.com/kasa_le/items/d92845c338eb3abd1e11)