### PR TITLE
Rich text

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_widget_key/samples/widget_key/widget_key.dart';
+import 'package:flutter_widget_key/samples/widgets/widgets.dart';
 import 'package:hexcolor/hexcolor.dart';
 
 class HomePage extends StatelessWidget {
@@ -21,6 +22,31 @@ class HomePage extends StatelessWidget {
       body: Center(
         child: Column(
           children: [
+            GestureDetector(
+              onTap: () => _onPressed(context, const Widgets()),
+              child: Card(
+                shape: RoundedRectangleBorder(
+                  side: BorderSide(
+                    color: HexColor('002E94'),
+                  ),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
+                ),
+                elevation: 0,
+                child: SizedBox(
+                  width: 200,
+                  height: 100,
+                  child: Center(
+                    child: Text(
+                      'Widgets',
+                      style: TextStyle(
+                        color: HexColor('002E94'),
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
             GestureDetector(
               onTap: () => _onPressed(context, const WidgetKey()),
               child: Card(
@@ -45,7 +71,7 @@ class HomePage extends StatelessWidget {
                   ),
                 ),
               ),
-            )
+            ),
           ],
         ),
       ),

--- a/lib/samples/widgets/rich_text.dart
+++ b/lib/samples/widgets/rich_text.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class RichTextWidget extends StatelessWidget {
+  const RichTextWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Learning widgets',
+          style: TextStyle(color: Colors.grey[700]),
+        ),
+      ),
+      body: Center(
+        child: RichText(
+          text: TextSpan(
+            text: 'Hello ',
+            style: DefaultTextStyle.of(context).style,
+            children: const <TextSpan>[
+              TextSpan(
+                text: 'bold',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              TextSpan(text: ' world!'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/samples/widgets/widgets.dart
+++ b/lib/samples/widgets/widgets.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_key/samples/widgets/rich_text.dart';
+
+class Widgets extends StatelessWidget {
+  const Widgets({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Learning widgets',
+          style: TextStyle(color: Colors.grey[700]),
+        ),
+      ),
+      body: Center(
+        child: Column(
+          children: [
+            ElevatedButton(
+              child: const Text('rich text'),
+              onPressed: () => _onPressed(context, const RichTextWidget()),
+            ),
+            const SizedBox(height: 10),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _onPressed(BuildContext context, Widget widget) async {
+  Navigator.push(
+    context,
+    MaterialPageRoute(
+      builder: (context) => widget,
+    ),
+  );
+}


### PR DESCRIPTION
### [RichText class](https://api.flutter.dev/flutter/widgets/RichText-class.html)
- `recognizer`
- 区切りたい文字ごとにTextSpan()で囲っていく
- [[Flutter]RichText、TextSpan Widgetなどの個人的まとめ](https://zenn.dev/t_fukuyama/articles/35074a8c3e65ec)
- [【Flutter】RichText でハッシュタグとかテキスト内リンクとか - Qiita](https://qiita.com/chooyan_eng/items/9e8f6ca2af55ea0e683a)
- [Flutter RichTextを使ってみた](https://cyublog.com/articles/flutter-ja/jp-richtext/)


## 余談
### DefaultTextStyle
- [そのDefaultTextStyle本当に大丈夫？？ - Qiita](https://qiita.com/b4tchkn/items/417b49bab8b996c15435)
- [FlutterでWidgetTree全体にTextStyleを適用する(DefaultTextStyle) - Qiita](https://qiita.com/nichiyoshi/items/d1f80e7e762da13157ec)

### SelectionRegistrar
- テキストの選択、コピー、切り取り、貼り付けの操作を制御するために使用される。
